### PR TITLE
Adding support for Trial Installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ class Pianoteq:
     @staticmethod
     def _find_installer_package():
         for fn in os.listdir(os.curdir):
-            if re.search(r'^pianoteq\w*_linux_v?\d*\.(7z|zip)$', fn) and os.path.isfile(fn):
+            if re.search(r'^pianoteq\w*_linux_(trial_)?v?\d*\.(7z|zip)$', fn) and os.path.isfile(fn):
                 return fn
         else:
             raise LookupError('Unable to find installer package.')


### PR DESCRIPTION
Previous regex would not detect the trial versions. This change optionally captures the trial affix of the file names.
Tested installation with trial and it works just as full versions.