### PR TITLE
Set proper audio limits for pianoteq.service

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,9 @@ Restart=on-failure
 RestartSec=2s
 KillMode=control-group
 TimeoutSec=infinity
+LimitRTPRIO=90
+LimitNICE=-10
+LimitMEMLOCK=500000
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
Apparently we need these lines in the `pianoteq.service` file as well as `/etc/security/limits.conf`. I get error logs in `/var/log/syslog` when I run the service without these lines.